### PR TITLE
Better handling of bjobs-related errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [ 3.6, 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [ 3.5, 3.6, 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2
 
@@ -42,20 +42,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run:  |
-              python -m pip install --upgrade pip
-              python -m pip install --pre -r dev-requirements.txt
-              
+        run:  make install-ci
+
       - name: Lint with flake8
-        run:  |
-              flake8 --count .
+        run:  make lint
 
 
   Testing:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [ 3.5, 3.6, 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2
 
@@ -65,15 +62,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run:  |
-              python -m pip install --upgrade pip
-              python -m pip install -r requirements.txt
-              python -m pip install --pre -r dev-requirements.txt
+        run:  make install-ci
 
       - name: Test and generate coverage report with pytest
-        run:  |
-              cd tests/ || exit 1
-              pytest --cov=./ --cov-report=xml
+        run:  make test-ci
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This document tracks changes to the `master` branch of the profile.
 
 ## 23/10/2020
 
+### Changed
+
 - When log file is not found, we now return failed instead of running. Returning running
   was effectively causing an infinite loop.
 - Unknown line status now also returns failed instead of raising an error. Raising

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,23 @@
 
 This document tracks changes to the `master` branch of the profile.
 
+## 23/10/2020
+
+- When log file is not found, we now return failed instead of running. Returning running
+  was effectively causing an infinite loop.
+- Unknown line status now also returns failed instead of raising an error. Raising
+  errors without returning a status causes problems with the snakemake master process.
+
 ## 09/04/2020
 
-
-
 **Added:**
-- Look at the log file if `bsub` returns an empty job status. See [#5][5] for more information.
-- Allow specifying per-rule cluster resource settings (similar to deprecated cluster config). See [#15][15] and [#7][7] for more information.
+- Look at the log file if `bsub` returns an empty job status. See [#5][5] for more
+  information.
+- Allow specifying per-rule cluster resource settings (similar to deprecated cluster
+  config). See [#15][15] and [#7][7] for more information.
 - Added a `CONTRIBUTING.md` document [#15][15]
-- TESTS!! A big thanks to [@leoisl](https://github.com/leoisl) for getting this off the ground. See [#12][12] for a request to add him to the repository as a contributor.
+- TESTS!! A big thanks to [@leoisl](https://github.com/leoisl) for getting this off the
+  ground. See [#12][12] for a request to add him to the repository as a contributor.
 - Add CHANGELOG to track major changes.
 
 **Changed:**
@@ -20,12 +28,13 @@ This document tracks changes to the `master` branch of the profile.
 - Robust memory handling [#18][18] and [#20][20]
 - README is now much more thorough [#15][15]
 
-[5]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/5
-[7]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/7
-[9]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/9
-[11]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/11
 [12]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/12
 [14]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/14
 [15]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/15
 [18]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/18
 [20]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/20
+[5]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/5
+[7]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/7
+[11]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/11
+[9]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/9
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+COVG_REPORT = tests/htmlcov/index.html
+OS := $(shell uname -s)
+BOLD := $(shell tput bold)
+NORMAL := $(shell tput sgr0)
+
+.PHONY: install-ci
+install-ci:
+	  python -m pip install --upgrade pip
+	  python -m pip install -r requirements.txt
+	  python -m pip install --pre -r dev-requirements.txt
+
+.PHONY: lint
+lint:
+	flake8 .
+
+# TEST ########################################################################
+.PHONY: test
+test:
+	cd tests/ && pytest --cov=src --cov-branch --cov-report=html --cov-report=term && cd ..
+
+.PHONY: test-ci
+test-ci:
+	cd tests/ && pytest --cov=src --cov-branch --cov-report=xml --cov-report=term && cd ..
+
+.PHONY: coverage
+coverage: test
+ifeq ($(OS), Linux)
+	xdg-open $(COVG_REPORT)
+else ifeq ($(OS), Darwin)
+	open $(COVG_REPORT)
+else
+	echo "ERROR: Unknown OS detected - $OS"
+endif
+

--- a/tests/test_OSLayer.py
+++ b/tests/test_OSLayer.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 
+from tests.src.CookieCutter import CookieCutter
 from tests.src.OSLayer import OSLayer, TailError
 
 
@@ -13,7 +16,10 @@ class TestTail:
 
         assert not actual
 
-    def test_nonExistentFile_raisesError(self):
+    @patch.object(
+        CookieCutter, CookieCutter.get_latency_wait.__name__, return_value=0.5
+    )
+    def test_nonExistentFile_raisesError(self, *mocks):
         path = "foo.bar"
         with pytest.raises(FileNotFoundError) as err:
             OSLayer.tail(path)

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -2,13 +2,10 @@ import unittest
 from subprocess import CalledProcessError
 from unittest.mock import patch, call
 
-import pytest
-
 from tests.src.OSLayer import OSLayer, TailError
 from tests.src.lsf_status import (
     StatusChecker,
     BjobsError,
-    UnknownStatusLine,
     UNKNOWN,
     ZOMBIE,
 )
@@ -348,10 +345,10 @@ class TestStatusChecker(unittest.TestCase):
     @patch.object(
         StatusChecker,
         StatusChecker._get_tail_of_log_file.__name__,
-        side_effect=TailError
+        side_effect=TailError,
     )
     def test_get_status_checking_log_raises_tail_error_status_is_failed(
-            self, get_lines_of_log_file_mock, run_process_mock
+        self, get_lines_of_log_file_mock, run_process_mock
     ):
         lsf_status_checker = StatusChecker(
             123, "dummy", wait_between_tries=0.001, max_status_checks=4

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, call
 
 import pytest
 
-from tests.src.OSLayer import OSLayer
+from tests.src.OSLayer import OSLayer, TailError
 from tests.src.lsf_status import (
     StatusChecker,
     BjobsError,
@@ -310,14 +310,14 @@ class TestStatusChecker(unittest.TestCase):
         StatusChecker._get_tail_of_log_file.__name__,
         side_effect=FileNotFoundError,
     )
-    def test_get_status_bjobs_fails_log_file_does_not_yet_exists_job_status_is_running(
+    def test_get_status_bjobs_fails_log_file_does_not_exist_job_status_is_failed(
         self, get_lines_of_log_file_mock, run_process_mock
     ):
         lsf_status_checker = StatusChecker(
             123, "dummy", wait_between_tries=0.001, max_status_checks=4
         )
         actual = lsf_status_checker.get_status()
-        expected = "running"
+        expected = lsf_status_checker.FAILED
         self.assertEqual(actual, expected)
         assert_called_n_times_with_same_args(
             run_process_mock, 4, "bjobs -o 'stat' -noheader 123"
@@ -337,7 +337,27 @@ class TestStatusChecker(unittest.TestCase):
             123, "dummy", wait_between_tries=0.001, max_status_checks=4
         )
         actual = lsf_status_checker.get_status()
-        expected = "running"
+        expected = lsf_status_checker.RUNNING
+        self.assertEqual(actual, expected)
+        assert_called_n_times_with_same_args(
+            run_process_mock, 4, "bjobs -o 'stat' -noheader 123"
+        )
+        get_lines_of_log_file_mock.assert_called_once_with()
+
+    @patch.object(OSLayer, OSLayer.run_process.__name__, side_effect=BjobsError)
+    @patch.object(
+        StatusChecker,
+        StatusChecker._get_tail_of_log_file.__name__,
+        side_effect=TailError
+    )
+    def test_get_status_checking_log_raises_tail_error_status_is_failed(
+            self, get_lines_of_log_file_mock, run_process_mock
+    ):
+        lsf_status_checker = StatusChecker(
+            123, "dummy", wait_between_tries=0.001, max_status_checks=4
+        )
+        actual = lsf_status_checker.get_status()
+        expected = lsf_status_checker.FAILED
         self.assertEqual(actual, expected)
         assert_called_n_times_with_same_args(
             run_process_mock, 4, "bjobs -o 'stat' -noheader 123"
@@ -357,7 +377,7 @@ class TestStatusChecker(unittest.TestCase):
             123, "dummy", wait_between_tries=0.001, max_status_checks=4
         )
         actual = lsf_status_checker.get_status()
-        expected = "running"
+        expected = lsf_status_checker.RUNNING
         self.assertEqual(actual, expected)
         assert_called_n_times_with_same_args(
             run_process_mock, 4, "bjobs -o 'stat' -noheader 123"
@@ -376,10 +396,10 @@ class TestStatusChecker(unittest.TestCase):
         lsf_status_checker = StatusChecker(
             123, "dummy", wait_between_tries=0.001, max_status_checks=4
         )
-        with pytest.raises(UnknownStatusLine) as err:
-            lsf_status_checker.get_status()
+        actual = lsf_status_checker.get_status()
+        expected = lsf_status_checker.FAILED
 
-        assert err.match("I am an unknown status line")
+        assert actual == expected
         assert_called_n_times_with_same_args(
             run_process_mock, 4, "bjobs -o 'stat' -noheader 123"
         )

--- a/{{cookiecutter.profile_name}}/CookieCutter.py
+++ b/{{cookiecutter.profile_name}}/CookieCutter.py
@@ -30,3 +30,7 @@ class CookieCutter:
     @staticmethod
     def get_zombi_behaviour() -> str:
         return "{{cookiecutter.ZOMBI_behaviour}}"
+
+    @staticmethod
+    def get_latency_wait() -> float:
+        return float("{{cookiecutter.latency_wait}}")

--- a/{{cookiecutter.profile_name}}/OSLayer.py
+++ b/{{cookiecutter.profile_name}}/OSLayer.py
@@ -1,7 +1,15 @@
 import subprocess
+import sys
+import time
 import uuid
 from pathlib import Path
 from typing import Tuple, List
+
+if not __name__.startswith("tests.src."):
+    sys.path.append(str(Path(__file__).parent.absolute()))
+    from CookieCutter import CookieCutter
+else:
+    from .CookieCutter import CookieCutter
 
 stdout = str
 stderr = str
@@ -48,7 +56,10 @@ class OSLayer:
     @staticmethod
     def tail(path: str, num_lines: int = 10) -> List[bytes]:
         if not Path(path).exists():
-            raise FileNotFoundError("{} does not exist.".format(path))
+            # allow for filesystem latency
+            time.sleep(CookieCutter.get_latency_wait())
+            if not Path(path).exists():
+                raise FileNotFoundError("{} does not exist.".format(path))
 
         process = subprocess.Popen(
             ["tail", "-n", str(num_lines), path],


### PR DESCRIPTION
### Changed

- When log file is not found, we now return failed instead of running. Returning running
  was effectively causing an infinite loop.
- Unknown line status now also returns failed instead of raising an error. Raising
  errors without returning a status causes problems with the snakemake master process.

I have also created a `Makefile` to make a few tasks easier/more reproducible. One thing I uncovered in the process was that we were calculating code coverage very incorrectly. We were testing the *test* code coverage. I have changed this, but it will cause a big drop in project coverage, but the important files are well covered.