### PR TITLE
🐛 Fix bug for legacy LSF system (v8.3)

### DIFF
--- a/{{cookiecutter.profile_name}}/lsf_status.py
+++ b/{{cookiecutter.profile_name}}/lsf_status.py
@@ -27,6 +27,17 @@ UNKNOWN = "UNKWN"
 ZOMBIE = "ZOMBI"
 
 
+def extract_job_status(bjobs_output):
+    import re
+
+    response = bjobs_output.split('\n')
+    if len(response) != 2:
+        return "UNKNOWN"
+
+    response = response[1]
+    return re.split("[\\t\\r\\n ]+", response)[2]
+
+
 class StatusChecker:
     SUCCESS = "success"
     RUNNING = "running"
@@ -70,7 +81,7 @@ class StatusChecker:
 
     @property
     def bjobs_query_cmd(self) -> str:
-        return "bjobs -o 'stat' -noheader {jobid}".format(jobid=self.jobid)
+        return "bjobs {jobid}".format(jobid=self.jobid)
 
     def _handle_unknown_job(self) -> str:
         if self.kill_unknown:
@@ -104,6 +115,8 @@ class StatusChecker:
                     stderr=error_stream
                 )
             )
+
+        output_stream = extract_job_status(output_stream)
 
         if output_stream == UNKNOWN:
             return self._handle_unknown_job()


### PR DESCRIPTION
In a legacy LSF system such as v8.3, the command `bjobs` does not support certain new arguments such as `--noheader` or `-o`. Furthermore, most of the time it is not realistic for snakemake users to upgrade LSF versions, which is tightly controlled by cluster admins. Therefore, it is essential to make this project compatible with legacy LSF systems. We can achieve this by simply using an alternative way to monitor job status.

This pull request includes a simple patch, which uses a plain `bjobs` command and for job status checking.

Note: I have tested the code under the following environment:

IBM Platform LSF 8.3.0.196409, May 10 2012

However, I haven't tested it for other LSF versions.