### PR TITLE
Dereplicate rule-specific parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 This document tracks changes to the `master` branch of the profile.
 
+## [0.1.0] - 18/01/2021
+
+### Added
+
+- Version tagging to allow for user notification of changes to functionality
+
+### Changed
+
+- Parameters given in the config file are now deduplicated. For instance, if a default
+  for `-q` is given, and a rule specifies `-q` also, the rule's value for `-q` is chosen.
+  Previously, parameters were just concatenated [[#36][36]]
+
 ## 23/10/2020
 
 ### Changed
@@ -30,13 +42,14 @@ This document tracks changes to the `master` branch of the profile.
 - Robust memory handling [#18][18] and [#20][20]
 - README is now much more thorough [#15][15]
 
-[12]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/12
-[14]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/14
-[15]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/15
-[18]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/18
-[20]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/20
-[5]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/5
-[7]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/7
-[11]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/11
-[9]: https://github.com/Snakemake-Profiles/snakemake-lsf/pull/9
-
+[12]: https://github.com/Snakemake-Profiles/lsf/issues/12
+[14]: https://github.com/Snakemake-Profiles/lsf/issues/14
+[15]: https://github.com/Snakemake-Profiles/lsf/pull/15
+[18]: https://github.com/Snakemake-Profiles/lsf/issues/18
+[20]: https://github.com/Snakemake-Profiles/lsf/pull/20
+[5]: https://github.com/Snakemake-Profiles/lsf/pull/5
+[7]: https://github.com/Snakemake-Profiles/lsf/issues/7
+[11]: https://github.com/Snakemake-Profiles/lsf/pull/11
+[9]: https://github.com/Snakemake-Profiles/lsf/pull/9
+[36]: https://github.com/Snakemake-Profiles/lsf/issues/36
+[0.1.0]: https://github.com/Snakemake-Profiles/lsf/releases/tag/0.1.0

--- a/tests/test_lsf_config.py
+++ b/tests/test_lsf_config.py
@@ -162,14 +162,12 @@ class TestParamsForRule:
         assert actual == expected
 
     def test_rule_and_default_present_returns_default_and_rule_params(self):
-        stream = StringIO(
-            "__default__: '-q foo'\nrule:\n  - '-P project'\n  - '-q bar'"
-        )
+        stream = StringIO("__default__: '-q foo'\nrule:\n  - '-P project'\n")
         config = Config.from_stream(stream)
         rulename = "rule"
 
         actual = config.params_for_rule(rulename)
-        expected = "-q foo -P project -q bar"
+        expected = "-q foo -P project"
 
         assert actual == expected
 
@@ -182,3 +180,24 @@ class TestParamsForRule:
         expected = "-P project -q bar"
 
         assert actual == expected
+
+    def test_rule_and_default_have_same_params_rule_params_take_precedent(self):
+        stream = StringIO(
+            "__default__: '-q foo'\nrule:\n  - '-P project'\n  - '-q bar'"
+        )
+        config = Config.from_stream(stream)
+        rulename = "rule"
+
+        actual = config.params_for_rule(rulename)
+        expected = "-q bar -P project"
+
+        assert actual == expected
+
+
+def test_args_to_dict():
+    args = '-W 0:01 -W 0:02 -J "test name"'
+
+    actual = Config.args_to_dict(args)
+    expected = {"-W": "0:02", "-J": "test name"}
+
+    assert actual == expected


### PR DESCRIPTION
### Added

- Version tagging to allow for user notification of changes to functionality

### Changed

- Parameters given in the config file are now deduplicated. For instance, if a default
  for `-q` is given, and a rule specifies `-q` also, the rule's value for `-q` is chosen.
  Previously, parameters were just concatenated [closes #36]