### PR TITLE
runtime resource added

### DIFF
--- a/{{cookiecutter.profile_name}}/lsf_submit.py
+++ b/{{cookiecutter.profile_name}}/lsf_submit.py
@@ -86,10 +86,14 @@ class Submitter:
     def resources_cmd(self) -> str:
         mem_in_clusters_units = self.mem_mb.to(self.memory_units)
         mem_value_to_submit = math.ceil(mem_in_clusters_units.value)
-        return (
-            "-M {mem} -n {threads} "
-            "-R 'select[mem>{mem}] rusage[mem={mem}] span[hosts=1]'"
-        ).format(mem=mem_value_to_submit, threads=self.threads)
+        resources_str = "-M {mem} -n {threads} -R 'select[mem>{mem}] " \
+                "rusage[mem={mem}] span[hosts=1]'" \
+            .format(mem=mem_value_to_submit, threads=self.threads)
+
+        for time_str in ("time", "runtime", "walltime"):
+            if self.resources.get(time_str, False):
+                resources_str += " -W {}".format(self.resources[time_str])
+        return resources_str
 
     @property
     def wildcards(self) -> dict:


### PR DESCRIPTION
Allows the usage of "time" / "runtime" / "walltime" as a snakemake resource, equivalent to "mem_mb".