### PR TITLE
Complex shell quote escaping fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,19 @@
 # Created by https://www.gitignore.io/api/python
 # Edit at https://www.gitignore.io/?templates=python
 
+### Vim ###
+*~
+*.swp
+
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Virtual environments
+venv
 
 # C extensions
 *.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 This document tracks changes to the `master` branch of the profile.
 
+## [unreleased]
+
+## Added
+
+- Support for complex quote-expansion via `shlex` [[#39]][39]]
+- Function docstrings in `lsf_config.py` for documentation
+
 ## [0.1.0] - 18/01/2021
 
 ### Added
@@ -52,4 +59,5 @@ This document tracks changes to the `master` branch of the profile.
 [11]: https://github.com/Snakemake-Profiles/lsf/pull/11
 [9]: https://github.com/Snakemake-Profiles/lsf/pull/9
 [36]: https://github.com/Snakemake-Profiles/lsf/issues/36
+[39]: https://github.com/Snakemake-Profiles/lsf/issues/39
 [0.1.0]: https://github.com/Snakemake-Profiles/lsf/releases/tag/0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ pytest --cov=./
 Please format code with [`black`][black] (default settings) before pushing.
 
 ```shell
+# Install latest black
+pip install black
 black .
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ install-ci:
 lint:
 	flake8 .
 
+fmt:
+	black .
+
+check-fmt:
+	black --check .
+
 # TEST ########################################################################
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ All settings are given with the `rule` name as the key, and the additional clust
 settings as a string ([scalar][yaml-collections]) or list
 ([sequence][yaml-collections]).
 
-#### Example `lsf.yaml` configuration
+#### Examples
 
 `Snakefile`
 
@@ -355,9 +355,9 @@ foo: "-P gpu -gpu 'gpu resources'"
 
 The above is also a valid form of the previous example but **not recommended**.
 
-#### Quote-escaping in `lsf.yaml`
+#### Quote-escaping
 
-Some lsf commands require multiple levels of quote-escaping.
+Some LSF commands require multiple levels of quote-escaping.
 For example, to exclude a node from job submission which has non-alphabetic characters
 in its name ([docs](https://www.ibm.com/support/knowledgecenter/SSWRJV_10.1.0/lsf_command_ref/bsub.__r.1.html?view=embed)): `bsub -R "select[hname!='node-name']"`.
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ All settings are given with the `rule` name as the key, and the additional clust
 settings as a string ([scalar][yaml-collections]) or list
 ([sequence][yaml-collections]).
 
-#### Examples
+#### Example `lsf.yaml` configuration
 
 `Snakefile`
 
@@ -354,6 +354,19 @@ foo: "-P gpu -gpu 'gpu resources'"
 ```
 
 The above is also a valid form of the previous example but **not recommended**.
+
+#### Quote-escaping in `lsf.yaml`
+
+Some lsf commands require multiple levels of quote-escaping.
+For example, to exclude a node from job submission which has non-alphabetic characters
+in its name ([docs](https://www.ibm.com/support/knowledgecenter/SSWRJV_10.1.0/lsf_command_ref/bsub.__r.1.html?view=embed)): `bsub -R "select[hname!='node-name']"`.
+
+You can specify this in `lsf.yaml` as:
+
+```yaml
+__default__:
+    - "-R \"select[hname!='node-name']\""
+```
 
 ## Known Issues
 

--- a/tests/test_lsf_config.py
+++ b/tests/test_lsf_config.py
@@ -1,6 +1,4 @@
 from io import StringIO
-import shlex
-import yaml
 from tests.src.lsf_config import Config
 
 

--- a/tests/test_lsf_config.py
+++ b/tests/test_lsf_config.py
@@ -205,11 +205,8 @@ __default__:
         stream = StringIO(config_string)
         config = Config.from_stream(stream)
         actual = config.params_for_rule("rule")
-        assert len(shlex.split(actual)) == 2
 
-        stream.seek(0)
-        data = yaml.safe_load(stream)["__default__"][0]
-        expected = shlex.join(shlex.split(data))
+        expected = "-R 'select[mem>2000] rusage[mem=2000]'"
 
         assert actual == expected
 
@@ -221,11 +218,8 @@ __default__:
         stream = StringIO(config_string)
         config = Config.from_stream(stream)
         actual = config.params_for_rule("rule")
-        assert len(shlex.split(actual)) == 2
 
-        stream.seek(0)
-        data = yaml.safe_load(stream)["__default__"][0]
-        expected = shlex.join(shlex.split(data))
+        expected = "-R 'select[hname!='\"'\"'escaped-hostname'\"'\"']'"
 
         assert actual == expected
 

--- a/tests/test_lsf_submit.py
+++ b/tests/test_lsf_submit.py
@@ -60,8 +60,7 @@ class TestSubmitter(unittest.TestCase):
             "-M {mem} -n 1 -R 'select[mem>{mem}] rusage[mem={mem}] span[hosts=1]'"
         ).format(mem=expected_mem)
         self.assertEqual(
-            lsf_submit.resources_cmd,
-            expected_resource_cmd,
+            lsf_submit.resources_cmd, expected_resource_cmd,
         )
         self.assertEqual(lsf_submit.jobname, "search_fasta_on_index.i=0")
         expected_logdir = Path("logdir") / expected_rule_name / expected_wildcards_str
@@ -74,8 +73,7 @@ class TestSubmitter(unittest.TestCase):
             '-o "{outlog}" -e "{errlog}" -J "search_fasta_on_index.i=0"'
         ).format(outlog=expected_outlog, errlog=expected_errlog)
         self.assertEqual(
-            lsf_submit.jobinfo_cmd,
-            expected_jobinfo_cmd,
+            lsf_submit.jobinfo_cmd, expected_jobinfo_cmd,
         )
         self.assertEqual(lsf_submit.queue_cmd, "-q q1")
         self.assertEqual(
@@ -315,10 +313,12 @@ class TestSubmitter(unittest.TestCase):
             "cluster_opt_3",
             "real_jobscript.sh",
         ]
-        content = (
-            "__default__:\n  - '-q queue'\n  - '-gpu -'\n"
-            "search_fasta_on_index: '-P project'"
-        )
+        content = """
+__default__:
+  - "-R 'select[mem>2000]'"
+  - '-gpu -'
+search_fasta_on_index: '-P project'
+"""
         stream = StringIO(content)
         lsf_config = Config.from_stream(stream)
         memory_units = Unit.MEGA
@@ -345,7 +345,7 @@ class TestSubmitter(unittest.TestCase):
         expected = (
             "bsub -M {mem} -n 1 -R 'select[mem>{mem}] rusage[mem={mem}] span[hosts=1]' "
             "{jobinfo} -q q1 cluster_opt_1 cluster_opt_2 cluster_opt_3 "
-            "-q queue -gpu - -P project "
+            "-R 'select[mem>2000]' -gpu - -P project "
             "real_jobscript.sh".format(mem=expected_mem, jobinfo=expected_jobinfo_cmd)
         )
 

--- a/tests/test_lsf_submit.py
+++ b/tests/test_lsf_submit.py
@@ -59,9 +59,7 @@ class TestSubmitter(unittest.TestCase):
         expected_resource_cmd = (
             "-M {mem} -n 1 -R 'select[mem>{mem}] rusage[mem={mem}] span[hosts=1]'"
         ).format(mem=expected_mem)
-        self.assertEqual(
-            lsf_submit.resources_cmd, expected_resource_cmd,
-        )
+        self.assertEqual(lsf_submit.resources_cmd, expected_resource_cmd)
         self.assertEqual(lsf_submit.jobname, "search_fasta_on_index.i=0")
         expected_logdir = Path("logdir") / expected_rule_name / expected_wildcards_str
         self.assertEqual(lsf_submit.logdir, expected_logdir)
@@ -72,9 +70,7 @@ class TestSubmitter(unittest.TestCase):
         expected_jobinfo_cmd = (
             '-o "{outlog}" -e "{errlog}" -J "search_fasta_on_index.i=0"'
         ).format(outlog=expected_outlog, errlog=expected_errlog)
-        self.assertEqual(
-            lsf_submit.jobinfo_cmd, expected_jobinfo_cmd,
-        )
+        self.assertEqual(lsf_submit.jobinfo_cmd, expected_jobinfo_cmd)
         self.assertEqual(lsf_submit.queue_cmd, "-q q1")
         self.assertEqual(
             lsf_submit.submit_cmd,

--- a/{{cookiecutter.profile_name}}/lsf_config.py
+++ b/{{cookiecutter.profile_name}}/lsf_config.py
@@ -29,7 +29,8 @@ class Config:
         elements of the string.
         Eg '-J "2" -q 3' --> {'-J': '2', '-q': '3'}
         """
-        args_iter = iter(shlex.split(args))
+        args_iter = shlex.shlex(args, posix=True)
+        args_iter.whitespace_split = True
         return OrderedDict(zip(args_iter, args_iter))
 
     @staticmethod
@@ -51,7 +52,7 @@ class Config:
         default_params = self.args_to_dict(self.default_params())
         rule_params = self.args_to_dict(self.get(rulename, ""))
         default_params.update(rule_params)
-        return shlex.join(chain.from_iterable(default_params.items()))
+        return " ".join(map(shlex.quote, chain.from_iterable(default_params.items())))
 
     @staticmethod
     def from_stream(stream: TextIO) -> "Config":

--- a/{{cookiecutter.profile_name}}/lsf_config.py
+++ b/{{cookiecutter.profile_name}}/lsf_config.py
@@ -24,8 +24,7 @@ class Config:
 
     @staticmethod
     def args_to_dict(args: str) -> Dict[str, str]:
-        """
-        Converts a string into a dictionary where key/value pairs are consecutive
+        """Converts a string into a dictionary where key/value pairs are consecutive
         elements of the string.
         Eg '-J "2" -q 3' --> {'-J': '2', '-q': '3'}
         """
@@ -43,8 +42,7 @@ class Config:
         return self.get("__default__", "")
 
     def params_for_rule(self, rulename: str) -> str:
-        """
-        Loads default + rule-specific arguments.
+        """Loads default + rule-specific arguments.
         Arguments specified for a rule override default-specified arguments.
         Shlex-joining is required to properly pass quoted escapes in yaml
         to the shell.


### PR DESCRIPTION
I found a case, described in #39, which failed on lsf cluster.
I propose here a solution which made it run successfully.

## Added

- Support for complex quote-expansion via `shlex` [#39]
- Function docstrings in `lsf_config.py` for documentation

Some details of the changes:

#39 issue:
 * The split argument string needs to be rejoined using `shlex`
 * Two unit tests for `lsf_config.py` to ensure quotes are shell-escaped
 * One modified unit test for `lsf_submit.py` to ensure quotes are
    shell-escaped
 * Rewrote `__init__` of `Config` object, to directly concatenate
    parameter lists. Makes downstream argument string production simpler to
    read.
 * Added function docstrings in `lsf_config.py` to make understanding easier

Docs/gitignore:
 * Add vim and venv to gitignore
 * Add example of complex quote escaping in `lsf.yaml` in the readme

The tests  pass- I've not tested this exact version of the code on the cluster, so maybe should do that too.
Cheers!