### PR TITLE
update jobid/log splitting for snakemake v7.1.1

### DIFF
--- a/{{cookiecutter.profile_name}}/lsf_status.py
+++ b/{{cookiecutter.profile_name}}/lsf_status.py
@@ -198,8 +198,8 @@ class StatusChecker:
 
 
 if __name__ == "__main__":
-    jobid = int(sys.argv[1])
-    outlog = sys.argv[2]
+    jobid = int(sys.argv[1].split()[0])
+    outlog = sys.argv[1].split()[1]
     if CookieCutter.get_unknwn_behaviour().lower() == "wait":
         kill_unknown = False
     elif CookieCutter.get_unknwn_behaviour().lower() == "kill":


### PR DESCRIPTION
The changes for multicluster support in snakemake v7.1.1 break the current lsf profile, so this resolves that behaviour. Probably a nicer way to split the args, but just a quick fix.