### PR TITLE
Wait for jobscript

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
       - uses: actions/checkout@v2
 
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
       - uses: actions/checkout@v2
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -30,5 +30,6 @@
   "max_jobs_per_second": 10,
   "max_status_checks": 1,
   "wait_between_tries": 0.001,
+  "jobscript_timeout": 10,
   "profile_name": "lsf"
 }

--- a/{{cookiecutter.profile_name}}/CookieCutter.py
+++ b/{{cookiecutter.profile_name}}/CookieCutter.py
@@ -42,3 +42,7 @@ class CookieCutter:
     @staticmethod
     def get_max_status_checks() -> int:
         return int("{{cookiecutter.max_status_checks}}")
+
+    @staticmethod
+    def jobscript_timeout() -> int:
+        return int("{{cookiecutter.jobscript_timeout}}")


### PR DESCRIPTION
Closes #58 

This adds a new cookiecutter variable `jobscript_timeout`, which waits for the jobscript to exist before submitting the job. The default is 10 seconds.